### PR TITLE
Implemented inline support

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -1,18 +1,56 @@
 use backtrace::backtrace::BacktraceGenerator;
 
-fn tar() {
+trait MyTrait {
+    fn test(&self);
+}
+
+struct MyStruct { }
+
+impl MyStruct {
+    fn new() -> MyStruct {
+        MyStruct {
+
+        }
+    }
+}
+
+impl MyTrait for MyStruct {
+    fn test(&self) {
+        taz();
+    }
+}
+
+fn tazz() {
     let backtrace_generator = BacktraceGenerator::new();
     backtrace_generator.unwind_stack();
 }
 
+
+#[inline(always)]
+fn taz() {
+    tazz();
+}
+
+#[inline(always)]
+fn tar() {
+    let my_struct = MyStruct::new();
+    my_struct.test();
+}
+
+#[inline(always)]
 fn bar() {
     tar();
 }
 
+#[inline(always)]
 fn foo() {
     bar();
 }
 
 fn main() {
+    let mut v = [1, 2, 3, 4, 5];
+    v[0] = 5;
+    v[1] = 2;
+    v[2] = 3;
     foo();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,12 +87,22 @@ pub mod backtrace {
                         .set_eh_frame(object_eh_frame.address());
 
             loop {
-                // Getting the function name
-                let function_name = self.get_function_name(&dwarf, ip)
-                                    .expect("No function was found at that address!");
-                
+                // Don't print the current function name
                 if function_index != -1 {
-                    println!("{}: {}", function_index, function_name);
+                    // Getting the function name
+                    let mut function_names = self.get_function_name(&dwarf, ip)
+                                         .expect("No function was found at that address!");
+
+                    // No function found at that address => should not happen soon
+                    if function_names.len() == 0 {
+                        function_names.insert(0, String::from("Name unknown"));
+                    }
+
+                    println!("{}: {}", function_index, function_names[0]);
+
+                    for function_name in &function_names[1..] {
+                        println!("   {}", function_name);
+                    }
                 }
                 function_index += 1;
 
@@ -136,9 +146,11 @@ pub mod backtrace {
 
         fn get_function_name(&self,
                              dwarf: &gimli::Dwarf<gimli::EndianSlice<'_, gimli::RunTimeEndian>>,
-                             address: u64) -> Result<String, gimli::Error> {
+                             address: u64) -> Result<Vec<String>, gimli::Error> {
             // Iterate over all compilation units.
             let mut iter = dwarf.units();
+            let mut function_found = false;
+            let mut function_names = Vec::new();
 
             while let Some(header) = iter.next()? {
                 // Parse the abbreviations and other information for this compilation unit.
@@ -149,6 +161,12 @@ pub mod backtrace {
                 while let Some((_, entry)) = entries.next_dfs()? {
                     // If we find an entry for a function, print it
                     if entry.tag() == gimli::DW_TAG_subprogram {
+                        // If we finished iterating over all the searched function children
+                        // we can stop the DWARF section iteration
+                        if function_found == true {
+                            break;
+                        }
+
                         let mut low_pc_addr = 0;
                         let mut high_pc_offset = 0;
 
@@ -177,20 +195,53 @@ pub mod backtrace {
                                 }
                             }
 
-                            // The DW_AT_name parsed for C binaries is AttributeValue::String
-                            if let Some(gimli::AttributeValue::String(slice)) = name_attr {
-                                function_name = slice.to_string()?;
-                            }
+                            function_found = true;
+                            function_names.insert(0, String::from(function_name));
+                        }
+                    } else if entry.tag() == gimli::DW_TAG_inlined_subroutine {
+                        let mut low_pc_addr = 0;
+                        let mut high_pc_offset = 0;
 
-                            if function_name != "" {
-                                return Ok(String::from(function_name));
+                        let low_pc_attr = entry.attr_value(gimli::DW_AT_low_pc)?;
+                        if let Some(gimli::AttributeValue::Addr(addr)) = low_pc_attr {
+                            low_pc_addr = addr;
+                        }
+
+                        let high_pc_attr = entry.attr_value(gimli::DW_AT_high_pc)?;
+                        if let Some(gimli::AttributeValue::Udata(offset)) = high_pc_attr {
+                            high_pc_offset = offset;
+                        }
+
+                        // Search the given address in the current function PC interval
+                        if address >= low_pc_addr && address <= low_pc_addr + high_pc_offset {
+                            // Get the abstract origin
+                            let abstract_origin = entry.attr_value(gimli::DW_AT_abstract_origin)?;
+
+                            if let Some(gimli::AttributeValue::UnitRef(unit_offset)) = abstract_origin {
+                                // let abstract_entry = dwarf.entry(unit_offset);
+                                let mut origin_entries_it = unit.entries_at_offset(unit_offset)?;
+                                let origin_entry = origin_entries_it.next_dfs()?;
+
+                                if let Some((_, origin_entry)) = origin_entry {
+                                    let name_attr = origin_entry.attr_value(gimli::DW_AT_name)?;
+
+                                    // The DW_AT_name parsed for Rust binaries is AttributeValue::DebugStrRef
+                                    if let Some(gimli::AttributeValue::DebugStrRef(offset)) = name_attr {
+                                        if let Ok(s) = dwarf.debug_str.get_str(offset) {
+                                            // Insert in the array of function names
+                                            function_names.insert(0, String::from(s.to_string()?));
+                                        }
+                                    }
+
+                                }
                             }
                         }
                     }
                 }
             }
 
-            Ok(String::from("Name unknown"))
+            // Ok(String::from("Name unknown"))
+            Ok(function_names)
         }
     }
 }


### PR DESCRIPTION
After finding a function's DIE, the inlined functions to the current function are found by iterating over the child DIEs and looking for the DW_TAG_inlined_subroutine tag. For every DW_TAG_inlined_subroutine (concrete instance), the abstract origin should be found afterwards (information about the function are stored there).